### PR TITLE
Feat(#17): sign 공통 레이아웃 구현 & RHF 라이브러리 설치

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.60.0",
         "react-textarea-autosize": "^8.5.9",
         "zustand": "^5.0.5"
       },
@@ -8208,6 +8209,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.60.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.60.0.tgz",
+      "integrity": "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.60.0",
     "react-textarea-autosize": "^8.5.9",
     "zustand": "^5.0.5"
   },

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,13 @@
+import CommonNavBar from "@/components/commons/NavBar";
+import { ReactNode } from "react";
+
+export default function SignLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className='flex h-screen w-full flex-col px-4'>
+      <CommonNavBar user={null} />
+      <main className='mt-20 flex w-full flex-col items-center'>
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,0 +1,3 @@
+export default function SignInPage() {
+  return <div>SignInPage</div>;
+}

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,0 +1,3 @@
+export default function SignUpPage() {
+  return <div>SignUpPage</div>;
+}


### PR DESCRIPTION
## 제목 규칙

`feat(issue 번호) : 기능명` 형태로 작성하세요.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 기능 변경
- [ ] 코드 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

- `from`: feat/17/signLayout
- `to`: Sprint/7

### 작업 내용 및 변경 사항

- sign in, up 페이지에서 공통적으로 사용될 레이아웃을 구현하였습니다.
- React Hook Form 라이브러리를 설치하였습니다.

### 결과 이미지(화면 캡쳐해서)

- 구현한 항목 캡쳐해서 올려주세요
![스크린샷 2025-07-08 오후 4 22 44](https://github.com/user-attachments/assets/24150210-2188-424a-ad10-a9f70cf9c184)

### Todo

- [x] 피그마 디자인에 맞춰 공통 컴포넌트 NavBar에 px-4를 추가로 적용하였습니다. 관련하여 의견이 있으시면 말씀주시면 감사하겠습니다.
- [x] 피그마 디자인에 맞춰 공통 컴포넌트 NavBar와 sing in, up 페이지와의 간격을 h-20만큼 부여하였습니다. 마찬가지로 의견이 있으시면 말씀주시면 감사하겠습니다.


### 이슈 링크

- 관련 이슈 번호 연결해주세요 e.g.`#1`
#17 

### 리뷰어 멘션하기

- 본인 username 제외하고 PR 날려주세요
  @joshuayeyo 
